### PR TITLE
fix: SpaceCreator DID handling and default provider

### DIFF
--- a/packages/react/src/components/space/SpaceCreator.tsx
+++ b/packages/react/src/components/space/SpaceCreator.tsx
@@ -178,12 +178,14 @@ export const SpaceCreatorProvider = ({
           return
         }
 
-        const toWebDID = (input?: string) =>
-          UcantoClient.Schema.DID.match({ method: 'web' }).from(input)
+        const toWebDID = (input?: string) => {
+          if (!input) return undefined
+          return UcantoClient.Schema.DID.match({ method: 'web' }).from(input)
+        }
 
         // Ensure gatewayHost is a valid URL string
         const finalGatewayHost = gatewayHost || 'https://w3s.link'
-        const gatewayId = toWebDID(gatewayDID) ?? toWebDID('did:web:w3s.link')
+        const gatewayId = toWebDID(gatewayDID) ?? toWebDID('did:web:w3s.link')!
 
         const storachaGateway = UcantoClient.connect({
           id: {
@@ -206,7 +208,7 @@ export const SpaceCreatorProvider = ({
           },
         } as any)
 
-        const provider = toWebDID(providerDID) || toWebDID('did:web:web3.storage')
+        const provider = toWebDID(providerDID) ?? toWebDID('did:web:storacha.network')!
         if (!provider) {
           const err = new Error('Failed to resolve provider DID')
           setError(err.message)


### PR DESCRIPTION
## Description

- **toWebDID undefined handling**: Added guard to prevent "Expected value of type string instead got undefined" error when gatewayDID/providerDID aren't passed
- **Default provider**: Changed from `did:web:web3.storage` to `did:web:storacha.network` to support Storacha-auth'd accounts and private spaces