### PR TITLE
docs: rewrite README, add CONTRIBUTING.md, and fix example docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,50 +1,168 @@
-## Contributing to Storacha Console Toolkit
+# Contributing to Storacha Console Toolkit
 
-Thank you for your interest in contributing to the Storacha Console Toolkit.
-This project extracts reusable UI from the main Storacha Console and makes it available as a plug-and-play toolkit for partner applications.
+Thanks for your interest in contributing. This guide walks through everything from getting the repo running locally to submitting a pull request.
 
-### Project layout
+---
 
-- **`packages/react`**: React bindings that provide the core auth context, hooks, and components.
-- **`packages/react-styled`**: React components that match the Storacha console look-and-feel.
-- **`examples/`**: Small example apps that demonstrate typical usage, including iframe / embedded flows.
+## Prerequisites
 
-### How to contribute
+- **Node.js** 18 or later
+- **pnpm** 8 or later (`npm install -g pnpm`)
+- A GitHub account
 
-- **Bugs / questions**: Open a GitHub Issue with a clear description, reproduction steps, and expected vs actual behavior.
-- **Features / improvements**: Open an Issue first to discuss the use‑case and API shape before starting work.
-- **Small fixes** (typos, small refactors, docs): You can usually open a PR directly without prior discussion.
+---
 
-### Development guidelines
+## Fork and clone
 
-- **Prefer composition over duplication**:  
-  - Reuse existing hooks and context (for example `Provider`, `useStorachaAuth`) instead of re-implementing logic.  
-  - If something from the console is useful here, extract and generalize it rather than copy‑pasting.
-- **API shape matters**:  
-  - New components and hooks should be usable both in simple drop‑in scenarios and in advanced, customized setups.  
-  - Prefer props that accept `className`, `style`, and/or render‑props for flexibility.
+1. Fork the repo on GitHub.
 
-### Coding style
+2. Clone your fork:
 
-- **Language / stack**: TypeScript, React function components, hooks-based APIs.
-- **Structure**: Keep files focused and small; factor shared logic into hooks or utilities where it improves clarity.
-- **Naming**: Use clear, descriptive names (for example `StorachaAuthEnsurer`) that match existing patterns.
+   ```bash
+   git clone https://github.com/storacha/console-toolkit
+   cd console-toolkit
+   ```
 
-### Tests and examples
+3. Add the upstream remote so you can pull in future changes:
 
-- **Tests**:  
-  - Add or update tests when you change behavior or add new features.  
-  - Prefer small, focused tests for hooks and components.
-- **Examples**:  
-  - When you add a new capability, consider updating or adding an example under `examples/` to show realistic usage.  
-  - Keep examples minimal but runnable, so integrators can copy patterns directly.
+   ```bash
+   git remote add upstream https://github.com/storacha/console-toolkit
+   ```
 
-### Pull request checklist
+---
 
-Before marking a PR as ready for review:
+## Install dependencies
 
-- **API** is consistent with existing components and hooks.  
-- **Tests** are added or updated where behavior changed.  
-- **Examples / docs** are updated when introducing new capabilities.
+From the repo root:
 
+```bash
+pnpm install
+```
 
+This installs dependencies for all packages and examples at once. The monorepo uses pnpm workspaces, so everything is linked together automatically.
+
+---
+
+## Project structure
+
+```
+packages/
+  react/              # @storacha/console-toolkit-react (headless components)
+  react-styled/       # @storacha/console-toolkit-react-styled (styled wrapper)
+
+examples/
+  full-app-headless/  # Complete example with custom UI
+  headless-auth/      # Auth-only with custom styling
+  styled-auth/        # Auth using the styled package
+  iframe-auth/        # Auth inside an iframe
+
+integration-guide/
+  dmail-integration/
+  web3mail-integration/
+```
+
+The two packages under `packages/` are what gets published to npm. The examples and integration guides are not published — they exist for development and reference.
+
+---
+
+## Making changes
+
+Create a branch for your work:
+
+```bash
+git checkout -b your-branch-name
+```
+
+If you are changing a component in `packages/react`, build it first so the examples can pick up your changes:
+
+```bash
+cd packages/react
+pnpm build
+```
+
+Or run it in watch mode while you develop:
+
+```bash
+pnpm dev
+```
+
+Then in a separate terminal, run the example you want to test against:
+
+```bash
+cd examples/full-app-headless
+pnpm dev
+```
+
+---
+
+## Running CI checks
+
+Before submitting a PR, run the full check suite from the repo root:
+
+```bash
+pnpm run lint
+pnpm run typecheck
+pnpm run test
+pnpm run build
+```
+
+Or run them all at once:
+
+```bash
+pnpm run ci
+```
+
+All four checks must pass. The CI pipeline runs the same commands on every PR.
+
+A few things to keep in mind:
+
+- **Lint**: ESLint runs against `src/**` and `test/**` in each package. Fix any errors before pushing.
+- **Typecheck**: TypeScript is set to strict mode. Don't use `any` unless there's a genuine reason.
+- **Tests**: Tests use Vitest and `@testing-library/react`. If you change a component's API or behavior, update or add tests in `packages/react/test/`.
+- **Build**: A clean build must succeed for all packages. If you add a new export, make sure it's in the package's `index.ts`.
+
+---
+
+## Commit style
+
+Keep commits focused. One logical change per commit. Use a short present-tense subject line:
+
+```
+fix(SpaceList): correct pagination cursor on refresh
+feat(StorachaAuth): add onAuthEvent callback prop
+```
+
+There is no strict enforced format, but keeping commits clean and descriptive makes review easier.
+
+---
+
+## Submitting a PR
+
+1. Push your branch to your fork:
+
+   ```bash
+   git push origin your-branch-name
+   ```
+
+2. Open a pull request against the `main` branch of `storacha/console-toolkit`.
+
+3. Fill in the PR description. Explain what changed and why. If it fixes an issue, reference it with `Closes #123`.
+
+4. CI will run automatically. Fix anything that fails before requesting review.
+
+---
+
+## Syncing with upstream
+
+If `main` has moved on since you branched:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+---
+
+## Questions
+
+If you are unsure about an approach or want feedback before writing code, open an issue first. It is easier to align on direction early than to rework a large PR after the fact.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,188 @@
 # Storacha Console Toolkit
 
-A plug-and-play UI library that enables Web3 applications to embed Storacha console features directly into their interface, eliminating redirect-based UX and double navigation.
+A React component library for embedding Storacha console features into any web application. It provides two packages: a headless package with all the logic and no styling, and a styled package with Storacha-branded UI ready to drop in.
 
-## Overview
+## Packages
 
-The toolkit provides headless React components with complete logic and no styling dependencies, giving you full control over appearance. Applications can quickly integrate Storacha features such as authentication, space management, file operations, and account settings.
+### `@storacha/console-toolkit-react`
 
-## Features
-
-### Authentication
-- Email-based authentication flow
-- Session management
-- Iframe support for embedded contexts
-
-### Space Management
-- **SpacePicker** - List and select spaces
-- **SpaceCreator** - Create public or private spaces
-- **SpaceList** - List content within a space with pagination
-- **SpaceEnsurer** - Ensure a space is selected before rendering
-- **ImportSpace** - Import existing spaces
-- **PlanGate** - Plan selection and validation
-
-### File Operations
-- **UploadTool** - Upload files, directories, or CAR files
-  - Drag & drop support
-  - Real-time progress tracking
-  - Support for public and private spaces
-- **FileViewer** - View file details (Root CID, Gateway URL, Shards)
-- File removal with shard management
-
-### Sharing
-- **SharingTool** - Share spaces via email or DID
-- Delegation management
-- Revocation support
-
-### Settings & Account Management
-- **SettingsProvider** - Account settings context
-- **RewardsSection** - Display referral counts, credits, and points
-- **AccountOverview** - Show account email and current plan
-- **UsageSection** - Display storage usage and per-space breakdown
-- **AccountManagement** - Account deletion and management
-- **ChangePlan** - Plan selection and billing administration
-
-## Installation
+Headless components — all authentication, space management, upload, and settings logic with zero built-in styling. You control every pixel.
 
 ```bash
-# Install headless components
 npm install @storacha/console-toolkit-react @storacha/ui-core
 ```
 
+### `@storacha/console-toolkit-react-styled`
+
+Pre-styled components that match the Storacha console UI exactly. Good for quick integrations where custom branding is not a requirement.
+
+```bash
+npm install @storacha/console-toolkit-react-styled @storacha/ui-core
+```
+
+---
+
+## What's included
+
+### Authentication
+
+`StorachaAuth` handles the complete email-based auth flow. It uses a compound component pattern so you can compose just the pieces you need.
+
+```tsx
+import { Provider, StorachaAuth } from '@storacha/console-toolkit-react'
+
+function App() {
+  return (
+    <Provider>
+      <StorachaAuth onAuthEvent={(event) => console.log(event)}>
+        <StorachaAuth.Ensurer>
+          <MyApp />
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
+  )
+}
+```
+
+Sub-components: `StorachaAuth.Form`, `StorachaAuth.Submitted`, `StorachaAuth.Ensurer`, `StorachaAuth.EmailInput`, `StorachaAuth.CancelButton`
+
+`StorachaAuth.Ensurer` handles the loading → form → submitted → authenticated state machine. Once the user is authenticated it renders `children`. Until then it renders the appropriate UI state.
+
+For iframe contexts, pass `enableIframeSupport={true}` to `StorachaAuth` and it will wait for authentication signals from the parent window rather than showing the form.
+
+### Space management
+
+Components for listing, creating, and selecting spaces:
+
+- **`SpacePicker`** — list spaces and let the user select one
+- **`SpaceCreator`** — create a new public or private space
+- **`SpaceEnsurer`** — ensure a space is selected before rendering children
+- **`SpaceList`** — paginated list of uploads within the current space
+- **`ImportSpace`** — import an existing space by DID
+- **`PlanGate`** — block access until the user has a valid plan
+
+### Uploads
+
+- **`UploadTool`** — upload files, directories, or CAR archives with drag-and-drop and real-time progress
+- **`FileViewer`** — inspect an upload: root CID, gateway URL, shards
+
+### Settings
+
+Wrap your settings UI in `SettingsProvider` to get access to plan info, usage stats, and account management actions.
+
+```tsx
+import { SettingsProvider, AccountOverview, UsageSection, AccountManagement, ChangePlan } from '@storacha/console-toolkit-react'
+
+function SettingsPage() {
+  return (
+    <SettingsProvider accountDeletionURL="https://your-deletion-form.example.com">
+      <AccountOverview />
+      <UsageSection />
+      <ChangePlan />
+      <AccountManagement />
+    </SettingsProvider>
+  )
+}
+```
+
+`SettingsProvider` accepts optional `referralsServiceURL` and `referralURL` props if you run a referral service.
+
+---
+
+## Provider setup
+
+`Provider` is the root context. It initializes the Storacha client and exposes accounts, spaces, and the client instance to all child components. Wrap your entire app (or the portion using toolkit components) in it.
+
+```tsx
+import { Provider } from '@storacha/console-toolkit-react'
+
+// Basic — connects to the default Storacha service
+<Provider>
+  <App />
+</Provider>
+
+// Custom service endpoint
+<Provider servicePrincipal={principal} connection={connection}>
+  <App />
+</Provider>
+```
+
+---
+
+## Hooks
+
+- **`useStorachaAuth()`** — access auth state and actions: `isAuthenticated`, `isLoading`, `email`, `submitted`, `setEmail`, `cancelLogin`, `logoutWithTracking`, `currentUser`
+- **`useSettingsContext()`** — access settings state: `plan`, `usage`, `accountEmail`, `planLoading`, `usageLoading`, and actions to refresh or manage the account
+- **`useW3()`** — low-level access to the raw context state from `Provider`
+
+---
+
+## Using the styled package
+
+```tsx
+import { StorachaAuth } from '@storacha/console-toolkit-react-styled'
+import '@storacha/console-toolkit-react-styled/styles.css'
+
+function App() {
+  return (
+    <StorachaAuth>
+      <StorachaAuth.Form />
+    </StorachaAuth>
+  )
+}
+```
+
+The styled package re-exports all headless components and adds Storacha-branded CSS on top. You still need `Provider` from the headless package.
+
+---
+
 ## Examples
 
-Complete working examples are available in the `examples/` directory:
+Working examples are in the `examples/` directory. Run any of them with `pnpm dev` from their directory.
 
-- **[headless-auth](./examples/headless-auth/)** - Custom styling with headless components
-- **[styled-auth](./examples/styled-auth/)** - Pre-styled components with console-exact UI
-- **[iframe-auth](./examples/iframe-auth/)** - Embedded authentication in iframe context
-- **[full-app-headless](./examples/full-app-headless/)** - Full headless integration: spaces, upload, files, sharing, and settings (custom UI)
+| Example | Description |
+|---------|-------------|
+| [`full-app-headless`](./examples/full-app-headless/) | Complete integration: auth, spaces, uploads, settings — fully custom UI |
+| [`headless-auth`](./examples/headless-auth/) | Auth-only example with custom styling |
+| [`styled-auth`](./examples/styled-auth/) | Drop-in auth using the styled package |
+| [`iframe-auth`](./examples/iframe-auth/) | Authentication inside an iframe |
 
-## Integration Guides
+Integration guide examples (more complex real-world integrations) are in [`integration-guide/`](./integration-guide/).
 
-Integration examples:
-
-- **[dmail-integration](./integration-guide/dmail-integration/)** - Dmail email authentication integration
-- **[web3mail-integration](./integration-guide/web3mail-integration/)** - Web3Mail (EtherMail) authentication integration
-
-See the [Integration Guide](./integration-guide/README.md) for detailed documentation.
+---
 
 ## Development
 
+This is a pnpm monorepo.
+
 ```bash
-# Install dependencies
+# Install all dependencies
 pnpm install
 
-# Build packages
+# Build all packages
 pnpm build
 
-# Run examples
-cd examples/full-app-headless && pnpm dev
-cd integration-guide/dmail-integration && pnpm dev
-cd integration-guide/web3mail-integration && pnpm dev
+# Run tests across all packages
+pnpm test
+
+# Run the full CI check (lint + typecheck + test + build)
+pnpm run ci
 ```
+
+To develop a specific example:
+
+```bash
+cd examples/full-app-headless
+pnpm dev
+```
+
+---
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get set up, make changes, run the CI checks, and submit a pull request.
+
+---
 
 ## License
 

--- a/examples/full-app-headless/README.md
+++ b/examples/full-app-headless/README.md
@@ -70,7 +70,7 @@ Feature UI is split under `src/components/` (e.g. `SharingView`, `UploadViews`, 
 | Spaces | `SpacePicker`, `SpaceCreator`, `SpaceList`, `ImportSpace`, `PlanGate` |
 | Files & uploads | `FileViewer`, `UploadTool`, remove/upload helpers |
 | Sharing | `SharingTool` |
-| Account & billing | `AccountOverview`, `UsageSection`, `AccountManagement`, `RewardsSection`, `ChangePlan` (used from Settings / change-plan views) |
+| Account & billing | `AccountOverview`, `UsageSection`, `AccountManagement`, `ChangePlan` (used from Settings / change-plan views) |
 
 See package docs and source under `packages/react` for the full API.
 

--- a/examples/headless-auth/README.md
+++ b/examples/headless-auth/README.md
@@ -17,17 +17,16 @@ pnpm dev
 ### Component Usage
 
 ```tsx
-import { Provider } from '@storacha/console-toolkit-react'
-import { StorachaAuth, useStorachaAuth } from '@storacha/console-toolkit-react'
+import { Provider, StorachaAuth, useStorachaAuth } from '@storacha/console-toolkit-react'
 
 function CustomForm() {
-  const [{ handleRegisterSubmit, submitted }] = useStorachaAuth()
-  
+  const { handleRegisterSubmit, isSubmitting } = useStorachaAuth()
+
   return (
     <form onSubmit={handleRegisterSubmit}>
       <label htmlFor="email">Email Address</label>
       <StorachaAuth.EmailInput id="email" />
-      <button type="submit" disabled={submitted}>
+      <button type="submit" disabled={isSubmitting}>
         Sign In
       </button>
     </form>

--- a/integration-guide/README.md
+++ b/integration-guide/README.md
@@ -1,112 +1,40 @@
 # Integration Guide
 
-This guide provides comprehensive instructions for integrating the Storacha Console Integration Toolkit into various platforms and applications.
-Live integrations demo examples avaialable for:-
-- Dmail
-- web3Mail
+Real-world integration examples showing how to embed the Storacha Console Toolkit into a partner application. Both examples demonstrate the complete flow: authentication, space management, file uploads, sharing, and settings.
 
-## 🚀 Quick Integration
+---
 
-### 🌐 Web3Mail Integration
-Complete integration with Web3Mail (EtherMail) for decentralized email authentication and file storage.
+## Examples
 
-**Location:** `web3mail-integration/`
+### Dmail Integration
 
-**Features:**
-- Web3Mail email authentication (@ethmail.cc, @ethermail.io)
-- Space creation and management
-- File upload with drag-and-drop
-- File sharing via email or DID
-- File viewing with CID and gateway URLs
+Integrates with Dmail (`@dmail.ai`) for email-based authentication and file storage. Includes iframe support for embedded contexts.
 
-**Quick Start:**
-```bash
-cd web3mail-integration
-pnpm install
-pnpm dev
-# Available at http://localhost:3002
-```
-
-📖 [Full Documentation →](./web3mail-integration/web3mail-integration.md)
-
-### 📧 Dmail Integration
-Complete integration with Dmail for email-based authentication and file storage.
-
-**Location:** `dmail-integration/`
-
-**Features:**
-- Dmail email authentication (@dmail.ai)
-- Space creation and management
-- File upload with progress tracking
-- File sharing via email or DID
-- Iframe support for embedded experiences
-
-**Quick Start:**
 ```bash
 cd dmail-integration
 pnpm install
 pnpm dev
-# Available at http://localhost:3001
+# http://localhost:3001
 ```
 
-📖 [Full Documentation →](./dmail-integration/dmail-integration.md)
+### Web3Mail Integration
 
-## 🚀 Getting Started
+Integrates with Web3Mail / EtherMail (`@ethmail.cc`, `@ethermail.io`) for decentralized email authentication and file storage.
 
-### Prerequisites
-
-- Node.js 18+ and pnpm installed
-- Built console-toolkit packages
-
-
-### Setup
-
-1. **Build the toolkit packages** (from console-toolkit root):
 ```bash
-pnpm -r build
-```
-
-2. **Navigate to an integration example:**
-```bash
-cd integration-guide/web3mail-integration
-# or
-cd integration-guide/dmail-integration
-```
-
-3. **Install dependencies:**
-```bash
+cd web3mail-integration
 pnpm install
-```
-
-4. **Run the development server:**
-```bash
 pnpm dev
+# http://localhost:3002
 ```
 
-## 📚 Core Packages
+---
 
-Both integrations use the following packages:
+## Provider stack
 
-- **`@storacha/console-toolkit-react`**: Core authentication hooks and providers
-  - `Provider`: Main context provider for Storacha client
-  - `StorachaAuth.Ensurer`: Handles authentication flow and state management
-  - `SpaceEnsurer`: Ensures at least one space exists
-  - `SpacePicker`: Space selection and management
-  - `SpaceCreator`: Create new spaces
-  - `UploadTool`: File upload functionality
-  - `SpaceList`: List and view uploads
-  - `FileViewer`: View file details
-  - `SharingTool`: Share spaces with others
+Both integrations follow the same provider order — this order matters:
 
-- **`@storacha/console-toolkit-react-styled`**: Pre-styled authentication components
-  - Pre-built styled components for faster development
-  - Consistent theming and branding
-
-## 🏗️ Architecture Pattern
-
-Both integrations follow the same architectural pattern:
-
-```typescript
+```tsx
 <Provider>
   <StorachaAuth>
     <StorachaAuth.Ensurer>
@@ -120,336 +48,38 @@ Both integrations follow the same architectural pattern:
 </Provider>
 ```
 
-**Component Flow:**
-1. **Provider**: Initializes the Storacha client
-2. **StorachaAuth**: Manages authentication state
-3. **StorachaAuth.Ensurer**: Ensures user is authenticated
-4. **SpaceEnsurer**: Ensures at least one space exists
-5. **SpacePicker**: Provides space selection context
-6. **Your Components**: Use hooks to access spaces, uploads, etc.
+Each layer is responsible for one thing:
 
-## 🎯 Key Features Implemented
+1. **`Provider`** — initializes the Storacha client
+2. **`StorachaAuth`** — manages authentication state and actions
+3. **`StorachaAuth.Ensurer`** — blocks rendering until authenticated; shows login UI otherwise
+4. **`SpaceEnsurer`** — ensures at least one space exists before rendering children
+5. **`SpacePicker`** — provides space selection context to all descendants
 
-### Authentication
-- Email-based authentication with platform-specific validation
-- Custom authentication forms with platform branding
-- Email verification flow
-- Session management
+---
 
-### Space Management
-- Create public or private spaces
-- List and search spaces
-- Space selection and context management
-- Space metadata (name, DID, access type)
+## Features covered
 
-### File Operations
-- Drag-and-drop file uploads
-- Upload progress tracking
-- Support for files, directories, and CAR files
-- File listing with pagination
-- File details (CID, gateway URL, shards)
-- File removal
+- Email-based authentication with platform-specific address validation
+- Space creation (public and private), listing, and selection
+- File uploads with drag-and-drop and progress tracking
+- File listing with pagination and CID/gateway URL details
+- File sharing via email or DID
+- Account settings: plan info, usage stats, account management
 
+---
 
-# 🎯 Platform-Specific Integrations
+## Running from the monorepo root
 
-## React Applications
+Build the toolkit packages first, then run either integration:
 
-### Next.js Integration
-1. Install dependencies:
+```bash
+# From the repo root
+pnpm install
+pnpm build
 
-`npm install @storacha/console-toolkit-react`
-
-2. Create a provider wrapper:
-
-```tsx
-// app/providers.tsx
-'use client'
-
-import { Provider } from '@storacha/console-toolkit-react'
-
-export function StorachaProvider({ children }: { children: React.ReactNode }) {
-  return (
-    <Provider
-      servicePrincipal="did:web:storacha.network"
-      connection={{ url: "https://api.storacha.network" }}
-    >
-      {children}
-    </Provider>
-  )
-}
+# Then start an integration
+cd integration-guide/dmail-integration && pnpm dev
+# or
+cd integration-guide/web3mail-integration && pnpm dev
 ```
-
-3. Add to your layout:
-
-```tsx
-// app/layout.tsx
-import { StorachaProvider } from './providers'
-
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <html lang="en">
-      <body>
-        <StorachaProvider>
-          {children}
-        </StorachaProvider>
-      </body>
-    </html>
-  )
-}
-```
-
-4. Use in your pages:
-
-```tsx
-// app/upload/page.tsx
-'use client'
-
-import { StorachaAuth, UploadTool } from '@storacha/console-toolkit-react'
-
-export default function UploadPage() {
-  return (
-    <StorachaAuth>
-      <StorachaAuth.Ensurer>
-        <UploadTool space={selectedSpace}>
-          <div>
-            <h1>Upload Files</h1>
-            {/* Your upload UI */}
-          </div>
-        </UploadTool>
-      </StorachaAuth.Ensurer>
-    </StorachaAuth>
-  )
-}
-```
-
-## Create React App Integration
-1. Install dependencies:
-
-`npm install @storacha/console-toolkit-react`
-
-2. Update your main App component:
-
-```ts
-// src/App.tsx
-import React from 'react'
-import { Provider, StorachaAuth, UploadTool } from '@storacha/console-toolkit-react'
-import './App.css'
-
-function App() {
-  return (
-    <Provider>
-      <StorachaAuth>
-        <StorachaAuth.Ensurer>
-          <UploadTool space={selectedSpace}>
-            <div className="App">
-              <header className="App-header">
-                <h1>My Storacha App</h1>
-                {/* Your app content */}
-              </header>
-            </div>
-          </UploadTool>
-        </StorachaAuth.Ensurer>
-      </StorachaAuth>
-    </Provider>
-  )
-}
-
-export default App
-```
-
-## Vue.js Integration
-
-1. Install dependencies:
-
-`npm install @storacha/console-toolkit-react`
-
-2. Create a Vue wrapper component:
-
-```vue
-<!-- StorachaWrapper.vue -->
-<template>
-  <div ref="storachaContainer"></div>
-</template>
-
-<script setup>
-import { onMounted, ref } from 'vue'
-import { createRoot } from 'react-dom/client'
-import { Provider, StorachaAuth, UploadTool } from '@storacha/console-toolkit-react'
-
-const storachaContainer = ref(null)
-
-onMounted(() => {
-  if (storachaContainer.value) {
-    const root = createRoot(storachaContainer.value)
-    root.render(
-      React.createElement(Provider, null,
-        React.createElement(StorachaAuth, null,
-          React.createElement(StorachaAuth.Ensurer, null,
-            React.createElement(UploadTool, { space: selectedSpace },
-              React.createElement('div', null, 'Storacha Components')
-            )
-          )
-        )
-      )
-    )
-  }
-})
-</script>
-```
-
-## Angular Integration
-
-1. Install dependencies:
-
-`npm install @storacha/console-toolkit-react`
-
-2. Create an Angular wrapper component:
-
-```ts
-// storacha-wrapper.component.ts
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core'
-import { createRoot } from 'react-dom/client'
-import { Provider, StorachaAuth, UploadTool } from '@storacha/console-toolkit-react'
-
-@Component({
-  selector: 'app-storacha-wrapper',
-  template: '<div #storachaContainer></div>'
-})
-export class StorachaWrapperComponent implements OnInit {
-  @ViewChild('storachaContainer', { static: true }) container!: ElementRef
-
-  ngOnInit() {
-    const root = createRoot(this.container.nativeElement)
-    root.render(
-      React.createElement(Provider, null,
-        React.createElement(StorachaAuth, null,
-          React.createElement(StorachaAuth.Ensurer, null,
-            React.createElement(UploadTool, { space: selectedSpace },
-              React.createElement('div', null, 'Storacha Components')
-            )
-          )
-        )
-      )
-    )
-  }
-}
-``` 
-
-### 🔧 Configuration
-- Set up environment variables for different environments:
-```
-NEXT_PUBLIC_SERVICE_URL=https://api.storacha.network
-NEXT_PUBLIC_SERVICE_PRINCIPAL=did:web:storacha.network
-NEXT_PUBLIC_UCAN_KMS_URL=https://kms.storacha.network
-NEXT_PUBLIC_UCAN_KMS_DID=did:web:kms.storacha.network
-```
-
-### Unit Testing
-
-```tsx
-// auth.test.tsx
-import { render, screen } from '@testing-library/react'
-import { Provider, Authenticator } from '@storacha/console-toolkit-react'
-
-test('renders authentication form', () => {
-  render(
-    <Provider>
-      <Authenticator>
-        <Authenticator.Form>
-          <Authenticator.EmailInput />
-        </Authenticator.Form>
-      </Authenticator>
-    </Provider>
-  )
-  
-  expect(screen.getByRole('form')).toBeInTheDocument()
-  expect(screen.getByRole('textbox')).toBeInTheDocument()
-})
-```
-
-### Integration Testing
-
-```tsx
-// integration.test.tsx
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { Provider, Authenticator, Uploader } from '@storacha/console-toolkit-react'
-
-test('complete upload flow', async () => {
-  const user = userEvent.setup()
-  
-  render(
-    <Provider>
-      <Authenticator>
-        <Uploader>
-          <Uploader.Form>
-            <Uploader.Input />
-            <button type="submit">Upload</button>
-          </Uploader.Form>
-        </Uploader>
-      </Authenticator>
-    </Provider>
-  )
-  
-  const fileInput = screen.getByRole('textbox', { name: /file/i })
-  const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
-  
-  await user.upload(fileInput, file)
-  await user.click(screen.getByRole('button', { name: /upload/i }))
-  
-  await waitFor(() => {
-    expect(screen.getByText(/upload complete/i)).toBeInTheDocument()
-  })
-})
-```
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-**1. Provider not found error:**
-```tsx
-// Make sure to wrap components with Provider
-<Provider>
-  <Authenticator>
-    {/* Your components */}
-  </Authenticator>
-</Provider>
-```
-
-**2. Authentication not working:**
-```tsx
-// Check service configuration
-<Provider
-  servicePrincipal="did:web:storacha.network"
-  connection={{ url: "https://api.storacha.network" }}
->
-  {/* Your components */}
-</Provider>
-```
-
-**3. Upload failing:**
-```tsx
-// Check space and account state
-const [{ accounts, spaces }] = useW3()
-const [{ status, error }] = useUploader()
-
-if (accounts.length === 0) {
-  return <div>Please authenticate first</div>
-}
-
-if (spaces.length === 0) {
-  return <div>No spaces available</div>
-}
-```
-
-## 📖 Learn More
-
-- [Web3Mail Integration Documentation](./web3mail-integration/web3mail-integration.md)
-- [Dmail Integration Documentation](./dmail-integration/dmail-integration.md)
-- [Console Toolkit Examples](../examples/)


### PR DESCRIPTION
## PR Description

  - Rewrote the root `README.md` from scratch — accurate to the current codebase,   correct component names, real usage examples, provider setup, hooks reference, styled package usage, and a contributing section linking to `CONTRIBUTING.md`
  - Added `CONTRIBUTING.md` with a full step-by-step guide: fork → clone → install → dev workflow → CI checks → commit style → PR submission
  - Fixed `examples/full-app-headless/README.md` — removed deleted `RewardsSection` from the toolkit surface area table
  - Fixed `examples/headless-auth/README.md` — corrected the `useStorachaAuth` code example (returns a flat object, not a tuple)
  - Rewrote `integration-guide/README.md` — removed all outdated content including non-existent component names (`Authenticator`, `Uploader`), broken test examples, Vue/Angular DOM-mount sections, and incorrect `Provider` API usage