### PR TITLE
 fix: remove UI core consumer dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thanks for your interest in contributing. This guide walks through everything fr
 2. Clone your fork:
 
    ```bash
-   git clone https://github.com/storacha/console-toolkit
+   git clone https://github.com/YOUR_USERNAME/console-toolkit
    cd console-toolkit
    ```
 
@@ -39,7 +39,7 @@ From the repo root:
 pnpm install
 ```
 
-This installs dependencies for all packages and examples at once. The monorepo uses pnpm workspaces, so everything is linked together automatically.
+This installs dependencies for all packages and examples at once and automatically builds the local packages (`packages/react` and `packages/react-styled`). The monorepo uses pnpm workspaces, so everything is linked together automatically.
 
 ---
 
@@ -73,16 +73,10 @@ Create a branch for your work:
 git checkout -b your-branch-name
 ```
 
-If you are changing a component in `packages/react`, build it first so the examples can pick up your changes:
+If you are changing a component in `packages/react` or `packages/react-styled`, run the package in watch mode so examples pick up your changes automatically:
 
 ```bash
 cd packages/react
-pnpm build
-```
-
-Or run it in watch mode while you develop:
-
-```bash
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A React component library for embedding Storacha console features into any web a
 Headless components — all authentication, space management, upload, and settings logic with zero built-in styling. You control every pixel.
 
 ```bash
-npm install @storacha/console-toolkit-react @storacha/ui-core
+npm install @storacha/console-toolkit-react
 ```
 
 ### `@storacha/console-toolkit-react-styled`
@@ -17,7 +17,7 @@ npm install @storacha/console-toolkit-react @storacha/ui-core
 Pre-styled components that match the Storacha console UI exactly. Good for quick integrations where custom branding is not a requirement.
 
 ```bash
-npm install @storacha/console-toolkit-react-styled @storacha/ui-core
+npm install @storacha/console-toolkit-react-styled
 ```
 
 ---
@@ -132,7 +132,7 @@ function App() {
 }
 ```
 
-The styled package re-exports all headless components and adds Storacha-branded CSS on top. You still need `Provider` from the headless package.
+The styled package re-exports `Provider`, `useW3`, and all headless components — you only need the one install command above.
 
 ---
 

--- a/examples/full-app-headless/package.json
+++ b/examples/full-app-headless/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@storacha/console-toolkit-react": "workspace:^",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/examples/full-app-headless/src/components/Dashboard.tsx
+++ b/examples/full-app-headless/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import type { UnknownLink } from '@storacha/ui-core'
+import type { UnknownLink } from '@storacha/console-toolkit-react'
 import {
   useW3,
   SpacePicker,

--- a/examples/full-app-headless/src/components/ImportSpaceView.tsx
+++ b/examples/full-app-headless/src/components/ImportSpaceView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react'
-import type { Space } from '@storacha/ui-core'
+import type { Space } from '@storacha/console-toolkit-react'
 import { useImportSpaceContext } from '@storacha/console-toolkit-react'
 
 export function ImportSpaceView({ onImport: _onImport }: { onImport: (space: Space) => void }) {

--- a/examples/full-app-styled/package.json
+++ b/examples/full-app-styled/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@storacha/console-toolkit-react-styled": "workspace:^",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/examples/full-app-styled/src/App.tsx
+++ b/examples/full-app-styled/src/App.tsx
@@ -18,7 +18,7 @@ import {
   useStorachaAuth,
 } from '@storacha/console-toolkit-react-styled'
 import type { Space, NavTab } from '@storacha/console-toolkit-react-styled'
-import type { UnknownLink } from '@storacha/ui-core'
+import type { UnknownLink } from '@storacha/console-toolkit-react-styled'
 
 function Console() {
   const [{ spaces }] = useW3()

--- a/examples/headless-auth/package.json
+++ b/examples/headless-auth/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@storacha/console-toolkit-react": "workspace:^",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/examples/iframe-auth/package.json
+++ b/examples/iframe-auth/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@storacha/console-toolkit-react-styled": "workspace:^",
     "@storacha/console-toolkit-react": "workspace:^",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/examples/styled-auth/package.json
+++ b/examples/styled-auth/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@storacha/console-toolkit-react-styled": "workspace:^",
     "@storacha/console-toolkit-react": "workspace:^",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/integration-guide/dmail-integration/package.json
+++ b/integration-guide/dmail-integration/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@storacha/console-toolkit-react-styled": "workspace:*",
     "@storacha/console-toolkit-react": "workspace:*",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/integration-guide/dmail-integration/src/components/DmailSpaces.tsx
+++ b/integration-guide/dmail-integration/src/components/DmailSpaces.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import type { UnknownLink } from '@storacha/ui-core'
+import type { UnknownLink } from '@storacha/console-toolkit-react'
 
 import {
   SpaceEnsurer,

--- a/integration-guide/dmail-integration/src/components/DmailUploadTool.tsx
+++ b/integration-guide/dmail-integration/src/components/DmailUploadTool.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import type { UnknownLink } from '@storacha/ui-core'
+import type { UnknownLink } from '@storacha/console-toolkit-react'
 import {
   UploadTool,
   useUploadToolContext,

--- a/integration-guide/web3mail-integration/package.json
+++ b/integration-guide/web3mail-integration/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@storacha/console-toolkit-react": "workspace:*",
     "@storacha/console-toolkit-react-styled": "workspace:*",
-    "@storacha/ui-core": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/integration-guide/web3mail-integration/src/components/Web3MailSpaces.tsx
+++ b/integration-guide/web3mail-integration/src/components/Web3MailSpaces.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react'
-import type { Space, UnknownLink } from '@storacha/ui-core'
+import type { Space, UnknownLink } from '@storacha/console-toolkit-react'
 import {
   SpacePicker,
   SpaceCreator,

--- a/integration-guide/web3mail-integration/src/components/Web3MailUploadTool.tsx
+++ b/integration-guide/web3mail-integration/src/components/Web3MailUploadTool.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react'
-import type { UnknownLink } from '@storacha/ui-core'
+import type { UnknownLink } from '@storacha/console-toolkit-react'
 import {
   UploadTool,
   useUploadToolContext,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Storacha Console Integration Toolkit - Plug-and-play UI components for seamless integration",
   "packageManager": "pnpm@10.1.0",
   "scripts": {
+    "prepare": "pnpm --filter \"./packages/*\" run build",
     "build": "pnpm --filter \"./packages/*\" run build && pnpm --filter \"./examples/*\" --filter \"./integration-guide/*\" run build",
     "ci": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build",
     "dev": "pnpm -r dev",

--- a/packages/react-styled/src/index.ts
+++ b/packages/react-styled/src/index.ts
@@ -22,7 +22,7 @@ export * from './components/UploadToolView.js'
 export * from './components/SharingToolView.js'
 export * from './components/SettingsPage.js'
 export { Provider, useW3, useStorachaAuth } from '@storacha/console-toolkit-react'
-export type { Space } from '@storacha/ui-core'
+export type { Space, UnknownLink } from '@storacha/console-toolkit-react'
 export * from './assets/index.js'
 
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,6 +6,7 @@
  * giving you complete control over the appearance.
  */
 
+export type { Space, UnknownLink } from '@storacha/ui-core'
 export * from './components/StorachaAuth.js'
 export * from './hooks/useStorachaAuth.js'
 export * from './providers/Provider.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@storacha/console-toolkit-react':
         specifier: workspace:^
         version: link:../../packages/react
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -94,9 +91,6 @@ importers:
       '@storacha/console-toolkit-react-styled':
         specifier: workspace:^
         version: link:../../packages/react-styled
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -125,9 +119,6 @@ importers:
       '@storacha/console-toolkit-react':
         specifier: workspace:^
         version: link:../../packages/react
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -159,9 +150,6 @@ importers:
       '@storacha/console-toolkit-react-styled':
         specifier: workspace:^
         version: link:../../packages/react-styled
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -193,9 +181,6 @@ importers:
       '@storacha/console-toolkit-react-styled':
         specifier: workspace:^
         version: link:../../packages/react-styled
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -227,9 +212,6 @@ importers:
       '@storacha/console-toolkit-react-styled':
         specifier: workspace:*
         version: link:../../packages/react-styled
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -261,9 +243,6 @@ importers:
       '@storacha/console-toolkit-react-styled':
         specifier: workspace:*
         version: link:../../packages/react-styled
-      '@storacha/ui-core':
-        specifier: ^2.4.0
-        version: 2.4.145(encoding@0.1.13)
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
## Summary                                                                                                                                           
                                                            
  - Re-export `Space` and `UnknownLink` from `@storacha/console-toolkit-react` and `@storacha/console-toolkit-react-styled` so consumers never need to importfrom `@storacha/ui-core` directly                                                                                                                  
  - Remove `@storacha/ui-core` as a direct dependency from all examples and integration-guide projects; update all source imports to use toolkit packages                                                                      
  - Add `prepare` script to root `package.json` so `pnpm install` automatically  builds local packages — no separate build step needed after cloning                                                                                
  - Fix `CONTRIBUTING.md`: correct fork clone URL, update install instructions                                                                                                                                                                                       
  - Remove `@storacha/ui-core` from all public-facing install commands          