### PR TITLE
docs: rewrite README files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thanks for your interest in contributing. This guide walks through everything fr
 2. Clone your fork:
 
    ```bash
-   git clone https://github.com/storacha/console-toolkit
+   git clone https://github.com/YOUR_USERNAME/console-toolkit
    cd console-toolkit
    ```
 
@@ -39,7 +39,7 @@ From the repo root:
 pnpm install
 ```
 
-This installs dependencies for all packages and examples at once. The monorepo uses pnpm workspaces, so everything is linked together automatically.
+This installs dependencies for all packages and examples at once and automatically builds the local packages (`packages/react` and `packages/react-styled`). The monorepo uses pnpm workspaces, so everything is linked together automatically.
 
 ---
 
@@ -51,6 +51,7 @@ packages/
   react-styled/       # @storacha/console-toolkit-react-styled (styled wrapper)
 
 examples/
+  full-app-styled/    # Complete example using pre-styled components
   full-app-headless/  # Complete example with custom UI
   headless-auth/      # Auth-only with custom styling
   styled-auth/        # Auth using the styled package
@@ -73,16 +74,10 @@ Create a branch for your work:
 git checkout -b your-branch-name
 ```
 
-If you are changing a component in `packages/react`, build it first so the examples can pick up your changes:
+If you are changing a component in `packages/react` or `packages/react-styled`, run the package in watch mode so examples pick up your changes automatically:
 
 ```bash
 cd packages/react
-pnpm build
-```
-
-Or run it in watch mode while you develop:
-
-```bash
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,48 @@
 # Storacha Console Toolkit
 
-A React component library for embedding Storacha console features into any web application. It provides two packages: a headless package with all the logic and no styling, and a styled package with Storacha-branded UI ready to drop in.
+A React component library for embedding Storacha console features — authentication, spaces, uploads, sharing, and account management — into any web application. Ships two packages: a headless package with all the logic and zero styling, and a styled package with Storacha-branded UI ready to use.
 
 ## Packages
 
 ### `@storacha/console-toolkit-react`
 
-Headless components — all authentication, space management, upload, and settings logic with zero built-in styling. You control every pixel.
+Headless components. All behavior and state, no styling. You control the markup, CSS, and design system — the same approach as Radix UI or Headless UI.
 
 ```bash
-npm install @storacha/console-toolkit-react @storacha/ui-core
+npm install @storacha/console-toolkit-react
 ```
 
 ### `@storacha/console-toolkit-react-styled`
 
-Pre-styled components that match the Storacha console UI exactly. Good for quick integrations where custom branding is not a requirement.
+Pre-styled components matching the Storacha console UI exactly. Import one CSS file and everything is styled. Re-exports `Provider`, `useW3`, and all headless components so you only need this one package.
 
 ```bash
-npm install @storacha/console-toolkit-react-styled @storacha/ui-core
+npm install @storacha/console-toolkit-react-styled
 ```
 
 ---
 
-## What's included
+## Quick start
 
-### Authentication
-
-`StorachaAuth` handles the complete email-based auth flow. It uses a compound component pattern so you can compose just the pieces you need.
+### Headless
 
 ```tsx
-import { Provider, StorachaAuth } from '@storacha/console-toolkit-react'
+import {
+  Provider,
+  StorachaAuth,
+  SpacePicker,
+  SpaceList,
+  UploadTool,
+} from '@storacha/console-toolkit-react'
 
 function App() {
   return (
     <Provider>
-      <StorachaAuth onAuthEvent={(event) => console.log(event)}>
+      <StorachaAuth>
         <StorachaAuth.Ensurer>
-          <MyApp />
+          <SpacePicker>
+            {/* your UI here */}
+          </SpacePicker>
         </StorachaAuth.Ensurer>
       </StorachaAuth>
     </Provider>
@@ -44,110 +50,119 @@ function App() {
 }
 ```
 
-Sub-components: `StorachaAuth.Form`, `StorachaAuth.Submitted`, `StorachaAuth.Ensurer`, `StorachaAuth.EmailInput`, `StorachaAuth.CancelButton`
-
-`StorachaAuth.Ensurer` handles the loading → form → submitted → authenticated state machine. Once the user is authenticated it renders `children`. Until then it renders the appropriate UI state.
-
-For iframe contexts, pass `enableIframeSupport={true}` to `StorachaAuth` and it will wait for authentication signals from the parent window rather than showing the form.
-
-### Space management
-
-Components for listing, creating, and selecting spaces:
-
-- **`SpacePicker`** — list spaces and let the user select one
-- **`SpaceCreator`** — create a new public or private space
-- **`SpaceEnsurer`** — ensure a space is selected before rendering children
-- **`SpaceList`** — paginated list of uploads within the current space
-- **`ImportSpace`** — import an existing space by DID
-- **`PlanGate`** — block access until the user has a valid plan
-
-### Uploads
-
-- **`UploadTool`** — upload files, directories, or CAR archives with drag-and-drop and real-time progress
-- **`FileViewer`** — inspect an upload: root CID, gateway URL, shards
-
-### Settings
-
-Wrap your settings UI in `SettingsProvider` to get access to plan info, usage stats, and account management actions.
+### Styled
 
 ```tsx
-import { SettingsProvider, AccountOverview, UsageSection, AccountManagement, ChangePlan } from '@storacha/console-toolkit-react'
+import {
+  Provider,
+  StorachaAuth,
+  ConsoleLayout,
+  NavTabs,
+  SpaceList,
+  SettingsPage,
+} from '@storacha/console-toolkit-react-styled'
+import '@storacha/console-toolkit-react-styled/styles.css'
 
-function SettingsPage() {
+function App() {
   return (
-    <SettingsProvider accountDeletionURL="https://your-deletion-form.example.com">
-      <AccountOverview />
-      <UsageSection />
-      <ChangePlan />
-      <AccountManagement />
-    </SettingsProvider>
+    <Provider>
+      <StorachaAuth>
+        <StorachaAuth.Ensurer>
+          {/* your content */}
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
   )
 }
 ```
 
-`SettingsProvider` accepts optional `referralsServiceURL` and `referralURL` props if you run a referral service.
-
 ---
 
-## Provider setup
+## Components
 
-`Provider` is the root context. It initializes the Storacha client and exposes accounts, spaces, and the client instance to all child components. Wrap your entire app (or the portion using toolkit components) in it.
+### Auth
 
-```tsx
-import { Provider } from '@storacha/console-toolkit-react'
+| Component | Description |
+|---|---|
+| `Provider` | Root context. Initializes the Storacha client. Wrap your entire app in this. |
+| `StorachaAuth` | Email-based auth flow. Manages login, submitted, and authenticated states. |
+| `StorachaAuth.Ensurer` | Blocks rendering until authenticated. Shows login UI in the meantime. |
+| `StorachaAuth.Form` | Login form with render prop slots for logo, inputs, and submit button. |
+| `StorachaAuth.Submitted` | Post-submission confirmation UI with render prop slots. |
+| `StorachaAuth.EmailInput` | Controlled email input wired to auth state. |
+| `StorachaAuth.CancelButton` | Cancels a pending auth submission. |
 
-// Basic — connects to the default Storacha service
-<Provider>
-  <App />
-</Provider>
+### Spaces
 
-// Custom service endpoint
-<Provider servicePrincipal={principal} connection={connection}>
-  <App />
-</Provider>
-```
+| Component | Description |
+|---|---|
+| `SpacePicker` | Space selection context with `.Search` and `.List` sub-components. |
+| `SpaceCreator` | Creates a new space. Accepts `providerDID`, `gatewayHost`, `gatewayDID`. |
+| `SpaceList` | Lists uploads within the current space. Includes `.List` and `.Pagination`. |
+| `SpaceEnsurer` | Ensures a space is selected before rendering children. |
+| `ImportSpace` | Imports an existing space via UCAN delegation. |
+| `PlanGate` | Blocks access until the user has a valid plan. |
+
+### Uploads
+
+| Component | Description |
+|---|---|
+| `UploadTool` | File, directory, and CAR upload with drag-and-drop and progress tracking. |
+| `FileViewer` | Displays root CID, gateway URL, and shards for an upload. Includes a remove action. |
+
+### Sharing
+
+| Component | Description |
+|---|---|
+| `SharingTool` | Share a space via email or DID. Creates UCAN delegations. |
+
+### Settings
+
+| Component | Description |
+|---|---|
+| `SettingsProvider` | Context for account info, plan data, and per-space usage stats. |
+| `AccountOverview` | Displays account email and current plan name. |
+| `UsageSection` | Per-space storage usage breakdown. |
+| `AccountManagement` | Account deletion request. |
+| `ChangePlan` | Plan selection, upgrade UI, and Stripe customer portal link. |
 
 ---
 
 ## Hooks
 
-- **`useStorachaAuth()`** — access auth state and actions: `isAuthenticated`, `isLoading`, `email`, `submitted`, `setEmail`, `cancelLogin`, `logoutWithTracking`, `currentUser`
-- **`useSettingsContext()`** — access settings state: `plan`, `usage`, `accountEmail`, `planLoading`, `usageLoading`, and actions to refresh or manage the account
-- **`useW3()`** — low-level access to the raw context state from `Provider`
-
----
-
-## Using the styled package
-
-```tsx
-import { StorachaAuth } from '@storacha/console-toolkit-react-styled'
-import '@storacha/console-toolkit-react-styled/styles.css'
-
-function App() {
-  return (
-    <StorachaAuth>
-      <StorachaAuth.Form />
-    </StorachaAuth>
-  )
-}
-```
-
-The styled package re-exports all headless components and adds Storacha-branded CSS on top. You still need `Provider` from the headless package.
+| Hook | Description |
+|---|---|
+| `useW3()` | Raw context: `client`, `accounts`, `spaces`, `logout`. |
+| `useStorachaAuth()` | Auth state and actions: `isAuthenticated`, `email`, `setEmail`, `logout`, `logoutWithTracking`. |
+| `useSettingsContext()` | Plan info, usage stats, and account management actions. |
+| `useSpacePickerContext()` | Selected space and setter. |
+| `useSpaceListContext()` | Upload list, pagination, loading, and reload. |
+| `useFileViewerContext()` | CID, URL, shards, and remove action for a viewed upload. |
+| `useUploadToolContext()` | Upload state, progress, file selection, and upload action. |
+| `useSharingToolContext()` | Sharing state and actions for email and DID delegation. |
+| `useImportSpaceContext()` | Import space state, DID, and UCAN actions. |
+| `usePlanGateContext()` | Plan status and `selectPlan` action. |
+| `useSpaceCreatorContext()` | Space creation state and submit action. |
 
 ---
 
 ## Examples
 
-Working examples are in the `examples/` directory. Run any of them with `pnpm dev` from their directory.
-
 | Example | Description |
-|---------|-------------|
-| [`full-app-headless`](./examples/full-app-headless/) | Complete integration: auth, spaces, uploads, settings — fully custom UI |
-| [`headless-auth`](./examples/headless-auth/) | Auth-only example with custom styling |
-| [`styled-auth`](./examples/styled-auth/) | Drop-in auth using the styled package |
-| [`iframe-auth`](./examples/iframe-auth/) | Authentication inside an iframe |
+|---|---|
+| [`full-app-styled`](./examples/full-app-styled/) | Complete console UI using pre-styled components — zero custom CSS required |
+| [`full-app-headless`](./examples/full-app-headless/) | Complete integration with fully custom UI and branding |
+| [`headless-auth`](./examples/headless-auth/) | Auth only with custom styling using render props |
+| [`styled-auth`](./examples/styled-auth/) | Minimal auth integration using the styled package |
+| [`iframe-auth`](./examples/iframe-auth/) | Auth embedded inside an iframe |
 
-Integration guide examples (more complex real-world integrations) are in [`integration-guide/`](./integration-guide/).
+More complex real-world integrations are in [`integration-guide/`](./integration-guide/).
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development workflow, and PR guidelines.
 
 ---
 
@@ -156,11 +171,8 @@ Integration guide examples (more complex real-world integrations) are in [`integ
 This is a pnpm monorepo.
 
 ```bash
-# Install all dependencies
+# Install all dependencies and build packages
 pnpm install
-
-# Build all packages
-pnpm build
 
 # Run tests across all packages
 pnpm test
@@ -175,12 +187,6 @@ To develop a specific example:
 cd examples/full-app-headless
 pnpm dev
 ```
-
----
-
-## Contributing
-
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get set up, make changes, run the CI checks, and submit a pull request.
 
 ---
 

--- a/examples/full-app-headless/README.md
+++ b/examples/full-app-headless/README.md
@@ -1,82 +1,120 @@
-# Full app (headless) example
+# full-app-headless
 
-This example shows how a **partner product** can embed the **Storacha Console Toolkit** inside its own application: **behavior and data** come from [`@storacha/console-toolkit-react`](../../packages/react/) **headless** components, while **layout, copy, and styling** stay entirely under your control.
+A complete Storacha console integration — auth, spaces, uploads, file viewing, sharing, and settings — built with headless components and fully custom UI. There is no Storacha branding anywhere; the app uses its own visual identity ("My Storage").
 
----
-
-## Purpose
-
-| Goal | What this example illustrates |
-|------|-------------------------------|
-| **Embed, don’t fork** | Use the same primitives the Storacha console uses (auth, spaces, uploads, sharing, billing surfaces) without copying internal UI packages. |
-| **Headless composition** | Compose small toolkit pieces (`SpacePicker`, `UploadTool`, `StorachaAuth`, …) and render **your** DOM with **your** CSS. |
-| **Partner branding** | Replace `src/styles.css` or swap in Tailwind, CSS Modules, or a design system—**no** stylesheet imports are required inside individual feature files beyond the global entry (`main.tsx`). |
-| **Reference implementation** | A single place to see wiring, provider order, and typical flows (pick space → list uploads → view file → share → settings). |
-
-**Typical integration path for partners**
-
-1. Add `@storacha/console-toolkit-react` (and peer deps) to your app.
-2. Wrap the authenticated area with **`Provider`** and the same context providers this example uses (`StorachaAuth`, `SpacePicker`, etc.).
-3. Build **your** shell (nav, header, routes)—here modeled as the **`Dashboard`** component—using toolkit hooks and compound components only for logic.
-4. Style with your tokens and components; keep class names or map toolkit render props to your UI library.
+This is the reference for integrating the toolkit when you want complete control over every pixel.
 
 ---
 
-## Run locally
+## Integration pattern
 
-**From the monorepo root** (after `pnpm install` at the repo root):
+Install the headless package:
 
 ```bash
-pnpm --filter @storacha/console-toolkit-example-full-app-headless dev
+npm install @storacha/console-toolkit-react
 ```
 
-**From this directory:**
+### Provider order
+
+Providers must wrap the app in this order:
+
+```tsx
+import {
+  Provider,
+  StorachaAuth,
+  SpacePicker,
+} from '@storacha/console-toolkit-react'
+
+function App() {
+  return (
+    <Provider>
+      <StorachaAuth>
+        <StorachaAuth.Ensurer
+          renderLoader={(type) => <MyLoader type={type} />}
+          renderForm={() => <MyLoginForm />}
+          renderSubmitted={() => <MyCheckEmailScreen />}
+        >
+          <SpacePicker>
+            <Dashboard />
+          </SpacePicker>
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
+  )
+}
+```
+
+`StorachaAuth.Ensurer` accepts render props for each auth state (`renderLoader`, `renderForm`, `renderSubmitted`). Once authenticated it renders `children`. `SpacePicker` provides space selection context to the entire authenticated area.
+
+### Building the auth form
+
+Use `StorachaAuth.Form` for the login UI. Every slot is a render prop — you own the markup:
+
+```tsx
+import { StorachaAuth } from '@storacha/console-toolkit-react'
+
+function MyLoginForm() {
+  return (
+    <StorachaAuth.Form
+      renderLogo={() => <MyLogo />}
+      renderEmailLabel={() => <label htmlFor="email">Email</label>}
+      renderEmailInput={() => (
+        <StorachaAuth.EmailInput id="email" className="my-input" />
+      )}
+      renderSubmitButton={(disabled) => (
+        <button type="submit" disabled={disabled}>
+          {disabled ? 'Authorizing...' : 'Authorize'}
+        </button>
+      )}
+    />
+  )
+}
+```
+
+### Accessing state with hooks
+
+Each domain exposes a context hook. Use hooks directly in your own components:
+
+```tsx
+import { useW3, useSpacePickerContext, useSpaceListContext } from '@storacha/console-toolkit-react'
+
+function SpaceView() {
+  const [{ accounts }] = useW3()
+  const [{ selectedSpace }] = useSpacePickerContext()
+  const [{ uploads, isLoading }, { reload }] = useSpaceListContext()
+
+  return (/* your UI */)
+}
+```
+
+### Styling
+
+All styles live in `src/styles.css` — a single flat CSS file imported only from `main.tsx`. There are no style imports inside individual component files. Swap this file for Tailwind, CSS Modules, or a design system without touching any component logic.
+
+### Component split
+
+The example splits feature UI across focused files under `src/components/`:
+
+| File | Feature |
+|---|---|
+| `Dashboard.tsx` | Main shell — nav, header, routing between views |
+| `SharingView.tsx` | `SharingTool` UI |
+| `UploadViews.tsx` | `UploadTool` and file listing UI |
+| `SettingsViews.tsx` | `SettingsProvider`, account overview, usage |
+| `ChangePlanViews.tsx` | `ChangePlan` UI |
+| `ImportSpaceView.tsx` | `ImportSpace` UI |
+| `RemoveFileButton.tsx` | File remove action |
+| `SpaceCreatorFields.tsx` | Space creation form fields |
+
+This mirrors how a real application would structure a multi-feature Storacha integration.
+
+---
+
+## Run this example
 
 ```bash
+# From the repo root
 pnpm install
+cd examples/full-app-headless
 pnpm dev
 ```
-
-Production build:
-
-```bash
-pnpm build
-```
-
----
-
-## Application shell
-
-`src/App.tsx` composes providers in a fixed order—**order matters** for context:
-
-| Layer | Role |
-|-------|------|
-| **`Provider`** | Root toolkit / client context. |
-| **`AuthSection`** | `StorachaAuth` + `StorachaAuth.Ensurer`—login UI, session, loading states. |
-| **`SpacePicker`** | Space search + list context for the signed-in user. |
-| **`Dashboard`** | **Your** main surface after auth: header (“Storacha Console” → home / spaces), navigation, and all feature views (spaces, create, import, upload, files, sharing, settings, change plan). |
-
-The **`Dashboard`** name reflects a common partner pattern: one top-level screen that hosts multiple toolkit-driven sections. A more literal name (e.g. `StorachaConsoleShell`) would also work if you prefer self-documenting file names in a large codebase.
-
-Feature UI is split under `src/components/` (e.g. `SharingView`, `UploadViews`, `SettingsViews`, `ImportSpaceView`) for readability; **global styles** live in **`src/styles.css`** and are imported only from **`main.tsx`**.
-
----
-
-## Toolkit surface area
-
-| Domain | Headless entry points (representative) |
-|--------|----------------------------------------|
-| Authentication | `StorachaAuth`, `StorachaAuth.Ensurer`, `StorachaAuth.Form`, … |
-| Spaces | `SpacePicker`, `SpaceCreator`, `SpaceList`, `ImportSpace`, `PlanGate` |
-| Files & uploads | `FileViewer`, `UploadTool`, remove/upload helpers |
-| Sharing | `SharingTool` |
-| Account & billing | `AccountOverview`, `UsageSection`, `AccountManagement`, `ChangePlan` (used from Settings / change-plan views) |
-
-See package docs and source under `packages/react` for the full API.
-
----
-
-## Styling notes
-
-- **Vanilla CSS** in `src/styles.css` demonstrates a complete custom skin.
-- You may replace it with any stack (Tailwind, CSS-in-JS, design tokens) as long as your markup still attaches the appropriate hooks (`className`, render props) expected by your composition.

--- a/examples/full-app-styled/README.md
+++ b/examples/full-app-styled/README.md
@@ -1,0 +1,127 @@
+# full-app-styled
+
+A complete Storacha console experience using pre-styled components. This example demonstrates how to get auth, space management, uploads, file viewing, sharing, and settings working with zero custom CSS — install the package, import the components, import one CSS file.
+
+The UI matches the official Storacha console exactly: yellow sidebar, fire background, red accents, Epilogue typeface.
+
+---
+
+## Integration pattern
+
+Install the styled package:
+
+```bash
+npm install @storacha/console-toolkit-react-styled
+```
+
+Import the CSS once at your app entry point:
+
+```tsx
+import '@storacha/console-toolkit-react-styled/styles.css'
+```
+
+`Provider`, `useW3`, `useStorachaAuth`, and all headless components are re-exported from the styled package — you only need one import source.
+
+### App composition
+
+The full console layout follows this structure:
+
+```tsx
+import {
+  Provider,
+  StorachaAuth,
+  ConsoleLayout,
+  NavTabs,
+  SpaceList,
+  SpaceDetail,
+  SpaceCreatorView,
+  ImportSpaceView,
+  SpaceUploadsView,
+  FileViewerView,
+  UploadToolView,
+  SharingToolView,
+  SettingsPage,
+  PlanGateView,
+  useW3,
+  useStorachaAuth,
+} from '@storacha/console-toolkit-react-styled'
+import type { Space, NavTab, UnknownLink } from '@storacha/console-toolkit-react-styled'
+import '@storacha/console-toolkit-react-styled/styles.css'
+
+function Console() {
+  const [{ spaces }] = useW3()
+  const auth = useStorachaAuth()
+  const [tab, setTab] = useState<NavTab>('spaces')
+  const [selectedSpace, setSelectedSpace] = useState<Space | undefined>()
+  const [selectedRoot, setSelectedRoot] = useState<UnknownLink | undefined>()
+
+  return (
+    <ConsoleLayout
+      spaces={spaces as Space[]}
+      selectedSpace={selectedSpace}
+      onSpaceSelect={(space) => { setSelectedSpace(space); setTab('uploads') }}
+      onLogout={() => auth.logoutWithTracking().then(() => window.location.reload())}
+      onHome={() => { setSelectedSpace(undefined); setTab('spaces') }}
+      nav={<NavTabs active={tab} onTabChange={setTab} hasSpace={!!selectedSpace} />}
+    >
+      {tab === 'settings' && <SettingsPage />}
+
+      {tab !== 'settings' && selectedSpace && (
+        <>
+          <SpaceDetail space={selectedSpace} onBack={() => setSelectedSpace(undefined)} />
+          {tab === 'uploads' && !selectedRoot && (
+            <SpaceUploadsView space={selectedSpace} onItemSelect={setSelectedRoot} onUpload={() => setTab('upload')} />
+          )}
+          {tab === 'uploads' && selectedRoot && (
+            <FileViewerView space={selectedSpace} root={selectedRoot} onRemoved={() => setSelectedRoot(undefined)} />
+          )}
+          {tab === 'upload' && <UploadToolView space={selectedSpace} />}
+          {tab === 'share'  && <SharingToolView space={selectedSpace} />}
+        </>
+      )}
+
+      {tab !== 'settings' && !selectedSpace && tab === 'spaces' && (
+        <SpaceList spaces={spaces as Space[]} onSelect={(space) => { setSelectedSpace(space); setTab('uploads') }} />
+      )}
+      {tab !== 'settings' && !selectedSpace && tab === 'import' && (
+        <ImportSpaceView onImport={(space) => { setSelectedSpace(space); setTab('uploads') }} />
+      )}
+      {tab !== 'settings' && !selectedSpace && tab === 'create' && (
+        <SpaceCreatorView onCreated={(space) => { setSelectedSpace(space); setTab('uploads') }} />
+      )}
+    </ConsoleLayout>
+  )
+}
+
+function App() {
+  return (
+    <Provider>
+      <StorachaAuth>
+        <StorachaAuth.Ensurer>
+          <PlanGateView>
+            <Console />
+          </PlanGateView>
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
+  )
+}
+```
+
+### Key points
+
+- `ConsoleLayout` provides the sidebar, space selector, and logout. Pass `nav` as a prop for the tab bar.
+- `NavTabs` is dual-mode: home tabs (`spaces / import / create / settings`) vs space tabs (`uploads / share / upload / settings`), controlled by `hasSpace`.
+- The settings tab is rendered before space/home checks so it is always accessible regardless of selected space.
+- `PlanGateView` wraps the app and prompts plan selection if no plan is active.
+
+---
+
+## Run this example
+
+```bash
+# From the repo root
+pnpm install
+cd examples/full-app-styled
+pnpm dev
+```

--- a/examples/headless-auth/README.md
+++ b/examples/headless-auth/README.md
@@ -1,45 +1,129 @@
-# Headless Auth Example
+# headless-auth
 
-This example demonstrates how to use **headless authentication components** from `@storacha/console-toolkit-react` with **fully custom styling**.
+Auth-only integration using headless components. This example demonstrates how to build a completely custom authentication UI using `StorachaAuth` render props while keeping all styling under your own control. No Storacha branding is included.
 
-## What this example shows
-- Storacha authentication without built-in styles
-- Full control over layout and appearance
-- Usage of `className`, `style`, and render props
+Use this pattern when you only need authentication (no space management or uploads), or when building auth as an isolated step before the rest of your app mounts.
 
-## Run locally
+---
+
+## Integration pattern
+
+Install the headless package:
 
 ```bash
-pnpm install
-pnpm dev
+npm install @storacha/console-toolkit-react
 ```
 
-### Component Usage
+### Auth state machine
+
+`StorachaAuth.Ensurer` manages the full auth state machine. Provide a render prop for each state:
 
 ```tsx
-import { Provider, StorachaAuth, useStorachaAuth } from '@storacha/console-toolkit-react'
+import { Provider, StorachaAuth } from '@storacha/console-toolkit-react'
 
-function CustomForm() {
-  const { handleRegisterSubmit, isSubmitting } = useStorachaAuth()
-
+function App() {
   return (
-    <form onSubmit={handleRegisterSubmit}>
-      <label htmlFor="email">Email Address</label>
-      <StorachaAuth.EmailInput id="email" />
-      <button type="submit" disabled={isSubmitting}>
-        Sign In
-      </button>
-    </form>
+    <Provider>
+      <StorachaAuth>
+        <StorachaAuth.Ensurer
+          renderLoader={(type) => (
+            <div className="loader">
+              {type === 'initializing' ? 'Initializing...' : 'Authenticating...'}
+            </div>
+          )}
+          renderForm={() => <LoginForm />}
+          renderSubmitted={() => <CheckEmailScreen />}
+        >
+          <AuthenticatedApp />
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
   )
 }
 ```
 
-## Styling
+### Building the login form
 
-This example uses vanilla CSS, but you can use any styling solution:
+`StorachaAuth.Form` exposes every slot as a render prop. `StorachaAuth.EmailInput` is a controlled input wired to auth state:
 
-- Tailwind CSS
-- Emotion / styled-components
-- CSS Modules
-- Chakra UI / MUI
-- Your own CSS framework
+```tsx
+import { StorachaAuth } from '@storacha/console-toolkit-react'
+
+function LoginForm() {
+  return (
+    <StorachaAuth.Form
+      renderLogo={() => <MyLogo />}
+      renderEmailLabel={() => (
+        <label htmlFor="storacha-auth-email">Email</label>
+      )}
+      renderEmailInput={() => (
+        <StorachaAuth.EmailInput
+          id="storacha-auth-email"
+          className="my-email-input"
+          required
+        />
+      )}
+      renderSubmitButton={(disabled) => (
+        <button type="submit" disabled={disabled}>
+          {disabled ? 'Authorizing...' : 'Authorize'}
+        </button>
+      )}
+    />
+  )
+}
+```
+
+### Post-submission confirmation
+
+`StorachaAuth.Submitted` renders after the email is sent. Use `StorachaAuth.CancelButton` to allow the user to go back:
+
+```tsx
+import { StorachaAuth } from '@storacha/console-toolkit-react'
+
+function CheckEmailScreen() {
+  return (
+    <StorachaAuth.Submitted
+      renderTitle={() => <h2>Check your email</h2>}
+      renderMessage={(email) => (
+        <p>Click the link we sent to <strong>{email}</strong> to sign in.</p>
+      )}
+      renderCancelButton={() => (
+        <StorachaAuth.CancelButton className="cancel-btn">
+          Cancel
+        </StorachaAuth.CancelButton>
+      )}
+    />
+  )
+}
+```
+
+### Reading auth state
+
+Use `useStorachaAuth` and `useW3` in any component inside `Provider`:
+
+```tsx
+import { useW3, useStorachaAuth } from '@storacha/console-toolkit-react'
+
+function AuthenticatedApp() {
+  const [{ accounts }] = useW3()
+  const auth = useStorachaAuth()
+
+  return (
+    <div>
+      <p>Signed in as {accounts[0]?.toEmail()}</p>
+      <button onClick={() => auth.logout()}>Sign out</button>
+    </div>
+  )
+}
+```
+
+---
+
+## Run this example
+
+```bash
+# From the repo root
+pnpm install
+cd examples/headless-auth
+pnpm dev
+```

--- a/examples/iframe-auth/README.md
+++ b/examples/iframe-auth/README.md
@@ -1,31 +1,34 @@
-# Iframe Auth Example
+# iframe-auth
 
-This example demonstrates how to run Storacha authentication **inside an iframe** while the parent application controls UX.
+Storacha authentication embedded inside an iframe. This example demonstrates the `enableIframeSupport` prop and how a single app can serve as both the host page and the iframe content depending on how it is loaded.
 
-## What this example shows
-- Host app embeds an iframe containing Storacha authentication
-- User logs in inside the iframe
-- The host app receives authentication state (no redirects)
+Use this pattern when your integration lives inside an iframe context and you need auth to work without redirects or cross-window navigation.
 
-## Run locally
+---
+
+## Integration pattern
+
+Install the packages:
+
 ```bash
-pnpm install
-pnpm dev
+npm install @storacha/console-toolkit-react-styled
 ```
 
-## Implementation
+### The `enableIframeSupport` prop
+
+Pass `enableIframeSupport={true}` to `StorachaAuth` when running inside an iframe. This switches the auth flow to iframe-aware handling:
 
 ```tsx
-import { Provider } from '@storacha/console-toolkit-react'
-import { StorachaAuth, useStorachaAuth } from '@storacha/console-toolkit-react-styled'
+import { Provider, useW3, useStorachaAuth } from '@storacha/console-toolkit-react'
+import { StorachaAuth } from '@storacha/console-toolkit-react-styled'
 import '@storacha/console-toolkit-react-styled/styles.css'
 
-function IframeAuth() {
+function IframeApp() {
   return (
     <Provider>
       <StorachaAuth enableIframeSupport={true}>
         <StorachaAuth.Ensurer>
-          <YourApp />
+          <AuthenticatedContent />
         </StorachaAuth.Ensurer>
       </StorachaAuth>
     </Provider>
@@ -33,12 +36,44 @@ function IframeAuth() {
 }
 ```
 
-## Usage
+### Dual-mode rendering
 
-When loaded in an iframe, the component automatically:
-1. Detects iframe context
-2. Shows Storacha authentication UI (form, submitted state, or authenticated content)
-3. Manages session state appropriately
-4. Handles authentication flow without redirects
+A common pattern is a single app that detects whether it is loaded as an iframe or as the host page, and renders accordingly:
 
-The `enableIframeSupport={true}` prop enables iframe-specific handling.
+```tsx
+function App() {
+  const isIframe = typeof window !== 'undefined' && window.self !== window.top
+
+  return (
+    <Provider>
+      {isIframe ? <IframeApp /> : <HostPage />}
+    </Provider>
+  )
+}
+```
+
+When loaded as an iframe, `IframeApp` renders the auth flow. When loaded as the top-level document, `HostPage` renders the host UI with the iframe embedded inside it.
+
+### Auth events
+
+Use `onAuthEvent` to observe the auth lifecycle:
+
+```tsx
+<StorachaAuth
+  enableIframeSupport={true}
+  onAuthEvent={(event, props) => {
+    console.log('auth event:', event, props)
+  }}
+>
+```
+
+---
+
+## Run this example
+
+```bash
+# From the repo root
+pnpm install
+cd examples/iframe-auth
+pnpm dev
+```

--- a/examples/styled-auth/README.md
+++ b/examples/styled-auth/README.md
@@ -1,31 +1,54 @@
-# Styled Auth Example
+# styled-auth
 
-This example demonstrates the **quickest way** to integrate Storacha authentication using pre-styled components that match console.storacha.network.
+The minimal path to working Storacha authentication. Install one package, import one CSS file, render two components. The UI matches the Storacha console exactly — fire background, logo, email form, and check-email confirmation screen included.
 
-## What you get
-- Console-exact UI
-- Built-in logo, background and styles
-- Complete authentication flow with almost zero setup
+---
 
-## Run locally
+## Integration pattern
+
+Install the styled package:
+
 ```bash
-pnpm install
-pnpm dev
+npm install @storacha/console-toolkit-react-styled
 ```
 
-## Implementation
+Import the CSS once at your entry point:
 
 ```tsx
-import { Provider } from '@storacha/console-toolkit-react'
-import { StorachaAuth, useStorachaAuth } from '@storacha/console-toolkit-react-styled'
 import '@storacha/console-toolkit-react-styled/styles.css'
+```
+
+### Minimal implementation
+
+`Provider`, `StorachaAuth`, `useW3`, and `useStorachaAuth` are all available from the styled package — no separate headless import needed:
+
+```tsx
+import {
+  Provider,
+  StorachaAuth,
+  useW3,
+  useStorachaAuth,
+} from '@storacha/console-toolkit-react-styled'
+import '@storacha/console-toolkit-react-styled/styles.css'
+
+function AuthenticatedApp() {
+  const [{ accounts }] = useW3()
+  const auth = useStorachaAuth()
+
+  return (
+    <div>
+      <p>Signed in as {accounts[0]?.toEmail()}</p>
+      <button onClick={auth.logoutWithTracking}>Sign out</button>
+    </div>
+  )
+}
 
 function App() {
   return (
     <Provider>
       <StorachaAuth>
         <StorachaAuth.Ensurer>
-          <YourApp />
+          <AuthenticatedApp />
         </StorachaAuth.Ensurer>
       </StorachaAuth>
     </Provider>
@@ -33,12 +56,28 @@ function App() {
 }
 ```
 
-## Customization
+`StorachaAuth.Ensurer` handles the full state machine — initializing, form, submitted, authenticated — with no configuration required.
 
-While using pre-styled components, you can still customize:
+### Optional props
 
-- `serviceName` - Custom service name
-- `termsUrl` - Custom terms of service URL
-- `onAuthEvent` - Analytics event tracking
+```tsx
+<StorachaAuth
+  onAuthEvent={(event, properties) => {
+    // analytics hook — receives events like 'login', 'logout'
+    analytics.track(event, properties)
+  }}
+>
+```
 
-For complete styling control, see the `headless-auth` example.
+For complete control over the auth UI, see the [`headless-auth`](../headless-auth/) example.
+
+---
+
+## Run this example
+
+```bash
+# From the repo root
+pnpm install
+cd examples/styled-auth
+pnpm dev
+```

--- a/integration-guide/README.md
+++ b/integration-guide/README.md
@@ -1,6 +1,6 @@
 # Integration Guide
 
-Real-world integration examples showing how to embed the Storacha Console Toolkit into a partner application. Both examples demonstrate the complete flow: authentication, space management, file uploads, sharing, and settings.
+Real-world integration examples showing how to embed the Storacha Console Toolkit into an application end-to-end. Both examples cover the complete flow: authentication, space management, file uploads, sharing, and settings.
 
 ---
 
@@ -10,23 +10,9 @@ Real-world integration examples showing how to embed the Storacha Console Toolki
 
 Integrates with Dmail (`@dmail.ai`) for email-based authentication and file storage. Includes iframe support for embedded contexts.
 
-```bash
-cd dmail-integration
-pnpm install
-pnpm dev
-# http://localhost:3001
-```
-
 ### Web3Mail Integration
 
 Integrates with Web3Mail / EtherMail (`@ethmail.cc`, `@ethermail.io`) for decentralized email authentication and file storage.
-
-```bash
-cd web3mail-integration
-pnpm install
-pnpm dev
-# http://localhost:3002
-```
 
 ---
 
@@ -35,17 +21,28 @@ pnpm dev
 Both integrations follow the same provider order — this order matters:
 
 ```tsx
-<Provider>
-  <StorachaAuth>
-    <StorachaAuth.Ensurer>
-      <SpaceEnsurer>
-        <SpacePicker>
-          {/* Your application components */}
-        </SpacePicker>
-      </SpaceEnsurer>
-    </StorachaAuth.Ensurer>
-  </StorachaAuth>
-</Provider>
+import {
+  Provider,
+  StorachaAuth,
+  SpaceEnsurer,
+  SpacePicker,
+} from '@storacha/console-toolkit-react'
+
+function App() {
+  return (
+    <Provider>
+      <StorachaAuth>
+        <StorachaAuth.Ensurer>
+          <SpaceEnsurer>
+            <SpacePicker>
+              {/* application components */}
+            </SpacePicker>
+          </SpaceEnsurer>
+        </StorachaAuth.Ensurer>
+      </StorachaAuth>
+    </Provider>
+  )
+}
 ```
 
 Each layer is responsible for one thing:
@@ -69,16 +66,12 @@ Each layer is responsible for one thing:
 
 ---
 
-## Running from the monorepo root
+## Run
 
-Build the toolkit packages first, then run either integration:
+From the repo root:
 
 ```bash
-# From the repo root
 pnpm install
-pnpm build
-
-# Then start an integration
 cd integration-guide/dmail-integration && pnpm dev
 # or
 cd integration-guide/web3mail-integration && pnpm dev

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Storacha Console Integration Toolkit - Plug-and-play UI components for seamless integration",
   "packageManager": "pnpm@10.1.0",
   "scripts": {
+    "prepare": "pnpm --filter \"./packages/*\" run build",
     "build": "pnpm --filter \"./packages/*\" run build && pnpm --filter \"./examples/*\" --filter \"./integration-guide/*\" run build",
     "ci": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build",
     "dev": "pnpm -r dev",


### PR DESCRIPTION
## Description 
 
- Rewrite all README files — root README now targets consumers with install commands, component reference, and hooks table; each example README documents its integration pattern with accurate code snippets; create missing `full-app-styled/README.md`    